### PR TITLE
Invalid path on powershell

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -50,9 +50,6 @@ func hasSuffix(fileName string, suffixes ...string) bool {
 	return false
 }
 
-type tarTraverser struct {
-}
-
 type myReadCloser struct {
 	reader io.Reader
 	closer io.Closer
@@ -79,11 +76,6 @@ func wrapReader(reader iowrapper.ReadCloseTypeParser) io.ReadCloser {
 		return r
 	}
 	return reader
-}
-
-type archiver interface {
-	NameAndIndex
-	traverse(generator func() Counter) *Either
 }
 
 type archiveItem interface {
@@ -197,7 +189,6 @@ func (zf *zipItem) Count(counter Counter) error {
 
 type ZipEntry struct {
 	entry Entry
-	file  *zip.File
 }
 
 func (ze *ZipEntry) Index() *Order {

--- a/counter.go
+++ b/counter.go
@@ -110,8 +110,7 @@ type lineCalculator struct {
 }
 
 func (lc *lineCalculator) calculate(data []byte) int64 {
-	var number int64
-	number = 0
+	var number int64 = 0
 	for _, datum := range data {
 		if datum == '\n' {
 			number++

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,18 @@ package wildcat
 import (
 	"net/url"
 	"os"
+	"strings"
 )
+
+func NormalizePath(path string) string {
+	if strings.HasSuffix(path, "\"") && strings.Index(path, "\"") == len(path)-1 {
+		newPath := strings.TrimRight(path, "\"")
+		if ExistDir(newPath) {
+			return newPath
+		}
+	}
+	return path
+}
 
 // ExistFile examines the given path is the regular file.
 // If given path is not found or is not a file, this function returns false.

--- a/utils.go
+++ b/utils.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 )
 
-func NormalizePath(path string) string {
+func NormalizePath(arg NameAndIndex) NameAndIndex {
+	path := arg.Name()
 	if strings.HasSuffix(path, "\"") && strings.Index(path, "\"") == len(path)-1 {
 		newPath := strings.TrimRight(path, "\"")
 		if ExistDir(newPath) {
-			return newPath
+			return NewArgWithIndex(arg.Index(), newPath)
 		}
 	}
-	return path
+	return arg
 }
 
 // ExistFile examines the given path is the regular file.

--- a/wildcat.go
+++ b/wildcat.go
@@ -131,10 +131,10 @@ func (wc *Wildcat) handleDir(arg NameAndIndex) *Either {
 
 func (wc *Wildcat) handleEntryAsFileList(entry Entry) *Either {
 	reader, err := entry.Open()
-	defer reader.Close()
 	if err != nil {
 		return &Either{Err: err}
 	}
+	defer reader.Close()
 	wc.ReadFileListFromReader(reader, entry.Index())
 	return &Either{Results: []*Result{}}
 }

--- a/wildcat.go
+++ b/wildcat.go
@@ -155,7 +155,8 @@ func (wc *Wildcat) handleEntry(entry Entry) *Either {
 }
 
 func (wc *Wildcat) handleItem(arg NameAndIndex) error {
-	name := NormalizePath(arg.Name())
+	newArg := NormalizePath(arg)
+	name := newArg.Name()
 	entry, ok := arg.(Entry)
 	switch {
 	case ok:

--- a/wildcat.go
+++ b/wildcat.go
@@ -155,7 +155,7 @@ func (wc *Wildcat) handleEntry(entry Entry) *Either {
 }
 
 func (wc *Wildcat) handleItem(arg NameAndIndex) error {
-	name := arg.Name()
+	name := NormalizePath(arg.Name())
 	entry, ok := arg.(Entry)
 	switch {
 	case ok:

--- a/wildcat.go
+++ b/wildcat.go
@@ -154,9 +154,9 @@ func (wc *Wildcat) handleEntry(entry Entry) *Either {
 	return &Either{Results: []*Result{}}
 }
 
-func (wc *Wildcat) handleItem(arg NameAndIndex) error {
-	newArg := NormalizePath(arg)
-	name := newArg.Name()
+func (wc *Wildcat) handleItem(oldArg NameAndIndex) error {
+	arg := NormalizePath(oldArg)
+	name := arg.Name()
 	entry, ok := arg.(Entry)
 	switch {
 	case ok:


### PR DESCRIPTION
#34 

`wildcat` running on PowerShell fails to open the directory if the directory name contains spaces.
The cause of the failure is the pathname has the double-quote only at the suffix; I do not know why.
As the temporary solution, `wildcat` checks the directory without the double quote if the path contains it only at the suffix.
Then, if the directory exists, `wildcat` employs the path without the double quote.